### PR TITLE
Add Conference Sponsorship Coordinator Role to the documentation.

### DIFF
--- a/roles/leadership/conference-sponsorship-coordinator.md
+++ b/roles/leadership/conference-sponsorship-coordinator.md
@@ -4,35 +4,27 @@
 The Conference Sponsorship Coordinator plays a vital role in securing sponsorships for Black Python Devs' conferences. 
 
 ## Roles and Responsibilities
-<ol>
-<li>
-Sponsorship Acquisition:
-</li>
+
+#### Sponsorship Acquisition:
+
 
 * Identify and reach out to potential sponsors for Black Python Devs' conferences.
 * Develop compelling sponsorship packages tailored to the needs and interests of potential sponsors.
 * Negotiate sponsorship agreements and terms with interested parties.
 
 
-
-<li>Relationship Management:
-</li>
+#### Relationship Management:
 
 * Cultivate and maintain strong relationships with current and potential sponsors.
 * Act as the main point of contact for sponsors, addressing any inquiries or concerns they may have.
 * Provide regular updates and reports to sponsors regarding the status of their sponsorship and the impact of their contributions.
 
-
-<li>
-Collaboration:
-</li>
+#### Collaboration:
 
 * Work closely with other team members, including event organizers and marketing personnel, to ensure sponsorship deliverables are met.
 * Collaborate with the marketing team to promote sponsorship opportunities and maximize sponsor visibility before, during, and after conferences.
 
-<li>
-Documentation and Reporting:
-</li>
+#### Documentation and Reporting:
 
 * Maintain accurate records of sponsorship agreements, payments, and sponsor contact information.
 * Prepare regular reports on sponsorship revenue, trends, and opportunities for improvement.
@@ -48,4 +40,3 @@ The Conference Sponsorship Coordinator will be granted access to the following r
 * Sponsorship@blackpythondevs.com email address.
 * Shared documentation folder containing sponsorship agreements, templates, and contact information.
 * Collaboration tools used by the Black Python Devs documentation team.</li>
-

--- a/roles/leadership/conference-sponsorship-coordinator.md
+++ b/roles/leadership/conference-sponsorship-coordinator.md
@@ -9,67 +9,34 @@ The Conference Sponsorship Coordinator plays a vital role in securing sponsorshi
 Sponsorship Acquisition:
 </li>
 
-<ul>
+* Identify and reach out to potential sponsors for Black Python Devs' conferences.
+* Develop compelling sponsorship packages tailored to the needs and interests of potential sponsors.
+* Negotiate sponsorship agreements and terms with interested parties.
 
-<li>
-Identify and reach out to potential sponsors for Black Python Devs' conferences.
-</li>
 
-<li>
-Develop compelling sponsorship packages tailored to the needs and interests of potential sponsors.
-</li>
-
-<li>
-Negotiate sponsorship agreements and terms with interested parties.
-</li>
-</ul>
 
 <li>Relationship Management:
 </li>
-<ul>
 
-<li>
-Cultivate and maintain strong relationships with current and potential sponsors.
-</li>
+* Cultivate and maintain strong relationships with current and potential sponsors.
+* Act as the main point of contact for sponsors, addressing any inquiries or concerns they may have.
+* Provide regular updates and reports to sponsors regarding the status of their sponsorship and the impact of their contributions.
 
-<li>
-Act as the main point of contact for sponsors, addressing any inquiries or concerns they may have.
-</li>
-
-<li>
-Provide regular updates and reports to sponsors regarding the status of their sponsorship and the impact of their contributions.
-</li>
-</ul>
 
 <li>
 Collaboration:
 </li>
-<ul>
 
-<li>
-Work closely with other team members, including event organizers and marketing personnel, to ensure sponsorship deliverables are met.
-</li>
-
-<li>
-Collaborate with the marketing team to promote sponsorship opportunities and maximize sponsor visibility before, during, and after conferences.
-</li>
-
-</ul>
+* Work closely with other team members, including event organizers and marketing personnel, to ensure sponsorship deliverables are met.
+* Collaborate with the marketing team to promote sponsorship opportunities and maximize sponsor visibility before, during, and after conferences.
 
 <li>
 Documentation and Reporting:
 </li>
-<ul>
 
-<li>
-Maintain accurate records of sponsorship agreements, payments, and sponsor contact information.
-</li>
+* Maintain accurate records of sponsorship agreements, payments, and sponsor contact information.
+* Prepare regular reports on sponsorship revenue, trends, and opportunities for improvement.
 
-<li>
-Prepare regular reports on sponsorship revenue, trends, and opportunities for improvement.
-</li>
-
-</ul>
 </ol>
 
 ## Requirements to fulfill role
@@ -77,15 +44,8 @@ This position requires strong communication skills, attention to detail, and the
 
 ## Access:
 The Conference Sponsorship Coordinator will be granted access to the following resources:
-<ol>
-<li>
-Sponsorship@blackpythondevs.com email address.
-</li>
 
-<li>
-Shared documentation folder containing sponsorship agreements, templates, and contact information.
-</li>
+* Sponsorship@blackpythondevs.com email address.
+* Shared documentation folder containing sponsorship agreements, templates, and contact information.
+* Collaboration tools used by the Black Python Devs documentation team.</li>
 
-<li>
-Collaboration tools used by the Black Python Devs documentation team.</li>
-</ol>

--- a/roles/leadership/conference-sponsorship-coordinator.md
+++ b/roles/leadership/conference-sponsorship-coordinator.md
@@ -29,8 +29,6 @@ The Conference Sponsorship Coordinator plays a vital role in securing sponsorshi
 * Maintain accurate records of sponsorship agreements, payments, and sponsor contact information.
 * Prepare regular reports on sponsorship revenue, trends, and opportunities for improvement.
 
-</ol>
-
 ## Requirements to fulfill role
 This position requires strong communication skills, attention to detail, and the ability to build and maintain relationships with potential sponsors.
 
@@ -39,4 +37,4 @@ The Conference Sponsorship Coordinator will be granted access to the following r
 
 * Sponsorship@blackpythondevs.com email address.
 * Shared documentation folder containing sponsorship agreements, templates, and contact information.
-* Collaboration tools used by the Black Python Devs documentation team.</li>
+* Collaboration tools used by the Black Python Devs documentation team.

--- a/roles/leadership/conference-sponsorship-coordinator.md
+++ b/roles/leadership/conference-sponsorship-coordinator.md
@@ -1,0 +1,91 @@
+# The Black Python Devs Conference Sponsorship Coordinator
+
+## Current Role Leader: Nuel
+The Conference Sponsorship Coordinator plays a vital role in securing sponsorships for Black Python Devs' conferences. 
+
+## Roles and Responsibilities
+<ol>
+<li>
+Sponsorship Acquisition:
+</li>
+
+<ul>
+
+<li>
+Identify and reach out to potential sponsors for Black Python Devs' conferences.
+</li>
+
+<li>
+Develop compelling sponsorship packages tailored to the needs and interests of potential sponsors.
+</li>
+
+<li>
+Negotiate sponsorship agreements and terms with interested parties.
+</li>
+</ul>
+
+<li>Relationship Management:
+</li>
+<ul>
+
+<li>
+Cultivate and maintain strong relationships with current and potential sponsors.
+</li>
+
+<li>
+Act as the main point of contact for sponsors, addressing any inquiries or concerns they may have.
+</li>
+
+<li>
+Provide regular updates and reports to sponsors regarding the status of their sponsorship and the impact of their contributions.
+</li>
+</ul>
+
+<li>
+Collaboration:
+</li>
+<ul>
+
+<li>
+Work closely with other team members, including event organizers and marketing personnel, to ensure sponsorship deliverables are met.
+</li>
+
+<li>
+Collaborate with the marketing team to promote sponsorship opportunities and maximize sponsor visibility before, during, and after conferences.
+</li>
+
+</ul>
+
+<li>
+Documentation and Reporting:
+</li>
+<ul>
+
+<li>
+Maintain accurate records of sponsorship agreements, payments, and sponsor contact information.
+</li>
+
+<li>
+Prepare regular reports on sponsorship revenue, trends, and opportunities for improvement.
+</li>
+
+</ul>
+</ol>
+
+## Requirements to fulfill role
+This position requires strong communication skills, attention to detail, and the ability to build and maintain relationships with potential sponsors.
+
+## Access:
+The Conference Sponsorship Coordinator will be granted access to the following resources:
+<ol>
+<li>
+Sponsorship@blackpythondevs.com email address.
+</li>
+
+<li>
+Shared documentation folder containing sponsorship agreements, templates, and contact information.
+</li>
+
+<li>
+Collaboration tools used by the Black Python Devs documentation team.</li>
+</ol>


### PR DESCRIPTION
This pull request adds documentation outlining the role responsibilities and requirements for the Conference Sponsorship Coordinator within the Black Python Devs team. The document provides a clear overview of the role's duties, including sponsorship acquisition, relationship management, collaboration, and documentation/reporting tasks. Additionally, it outlines the requirements to fulfill the role and specifies the access granted to the Coordinator.

**Changes:**

- Added the "Conference Sponsorship Coordinator Responsibilities" document to the roles folder.
- Document includes roles and responsibilities, requirements, and access details.