### PR TITLE
[Documentation]: Improve clarity of Conference Sponsorship Coordinators docs

### DIFF
--- a/roles/leadership/conference-sponsorship-coordinator.md
+++ b/roles/leadership/conference-sponsorship-coordinator.md
@@ -13,7 +13,7 @@ The Conference Sponsorship Coordinator is a regional liaison responsible for man
 
 ## Requirements to Fulfill the Role
 
-This position requires strong communication skills, attention to detail, and the ability to build and maintain relationships with potential sponsors.
+This position requires strong communication skills, attention to detail, and the ability to build and maintain relationships with sponsors.
 
 ## Responsibilities
 


### PR DESCRIPTION
This PR improves the clarity of docs to indicate that Conference Sponsorship Coordinators aren’t responsible for incoming sponsorships